### PR TITLE
fix(worker): import Billfish 3.x metadata from normalized tables

### DIFF
--- a/src/worker/billfish-library.ts
+++ b/src/worker/billfish-library.ts
@@ -200,7 +200,7 @@ function metadataFromRow(row: JsonObject): BillfishAssetMetadata {
     MAX_TEXT_LENGTH,
   ) || null;
   const sourcePageUrl = httpUrlValue(
-    firstValue(row, ['source_url', 'sourceUrl', 'origin_url', 'originUrl', 'url', 'website']),
+    firstValue(row, ['source_url', 'sourceUrl', 'origin_url', 'originUrl', 'origin', 'url', 'website']),
   );
   const tags = stringArray(firstValue(row, ['tags', 'tag', 'labels', 'keywords']));
   const thumbnailPath = textValue(
@@ -263,6 +263,181 @@ function readJsonMetadata(root: string): Map<string, string> {
   return result;
 }
 
+function tableExists(tableNames: ReadonlySet<string>, name: string): boolean {
+  return tableNames.has(name);
+}
+
+function safePathSegment(value: unknown): string | null {
+  const text = textValue(value, 1_024);
+  if (text === '' || text === '.' || text === '..' || text.includes('/') || text.includes('\\')) {
+    return null;
+  }
+  return text;
+}
+
+/**
+ * Billfish 3.x stores metadata across normalized tables (`bf_file`,
+ * `bf_folder`, `bf_material_userdata`, `bf_tag_v2`, `bf_tag_join_file`) and
+ * none of them carries a path column, so the generic single-table reader below
+ * silently drops every note, rating, URL, and tag. Index those tables here.
+ *
+ * Exported `.BillfishPack` archives flatten asset files to the archive root
+ * while the database still records the original folder hierarchy, so entries
+ * are registered both by their database path and by file name; the caller
+ * resolves flattened layouts through the by-name fallback.
+ */
+function readBillfish3Metadata(
+  database: BillfishDatabase,
+  tableNames: ReadonlySet<string>,
+  byPath: Map<string, BillfishAssetMetadata>,
+  byName: Map<string, BillfishAssetMetadata[]>,
+): boolean {
+  if (!tableExists(tableNames, 'bf_file')) return false;
+
+  const folders = new Map<number, { pid: number; name: string }>();
+  if (tableExists(tableNames, 'bf_folder')) {
+    try {
+      const rows = database.prepare('SELECT id, pid, name FROM bf_folder').all() as JsonObject[];
+      for (const row of rows) {
+        const id = finiteNumber(row.id);
+        const pid = finiteNumber(row.pid);
+        const name = safePathSegment(row.name);
+        if (id === undefined || pid === undefined || name === null) continue;
+        folders.set(id, { pid, name });
+      }
+    } catch {
+      // Folder hierarchy is optional; files fall back to name-only entries.
+    }
+  }
+
+  const userdata = new Map<number, { note: string; origin: string; score: unknown }>();
+  if (tableExists(tableNames, 'bf_material_userdata')) {
+    try {
+      const rows = database
+        .prepare('SELECT file_id, note, origin, score FROM bf_material_userdata')
+        .all() as JsonObject[];
+      for (const row of rows) {
+        const fileId = finiteNumber(row.file_id);
+        if (fileId === undefined) continue;
+        userdata.set(fileId, {
+          note: textValue(firstValue(row, ['note', 'comments_summary']), MAX_TEXT_LENGTH),
+          origin: textValue(row.origin, MAX_URL_LENGTH),
+          score: row.score,
+        });
+      }
+    } catch {
+      // Ratings/notes/URLs are optional metadata.
+    }
+  }
+
+  const tagNameById = new Map<number, string>();
+  const joinTable = tableExists(tableNames, 'bf_tag_join_file');
+  const tagTable = tableExists(tableNames, 'bf_tag_v2')
+    ? 'bf_tag_v2'
+    : tableExists(tableNames, 'bf_tag')
+      ? 'bf_tag'
+      : null;
+  if (tagTable) {
+    try {
+      const rows = database.prepare(`SELECT id, name FROM ${tagTable}`).all() as JsonObject[];
+      for (const row of rows) {
+        const id = finiteNumber(row.id);
+        const name = textValue(row.name, 255);
+        if (id === undefined || name === '') continue;
+        tagNameById.set(id, name);
+      }
+    } catch {
+      // Tags are optional metadata.
+    }
+  }
+  const tagIdsByFile = new Map<number, Set<number>>();
+  if (joinTable && tagNameById.size > 0) {
+    try {
+      const rows = database
+        .prepare('SELECT file_id, tag_id FROM bf_tag_join_file')
+        .all() as JsonObject[];
+      for (const row of rows) {
+        const fileId = finiteNumber(row.file_id);
+        const tagId = finiteNumber(row.tag_id);
+        if (fileId === undefined || tagId === undefined) continue;
+        const tags = tagIdsByFile.get(fileId) ?? new Set<number>();
+        tags.add(tagId);
+        tagIdsByFile.set(fileId, tags);
+      }
+    } catch {
+      // Tag joins are optional metadata.
+    }
+  }
+
+  let files: JsonObject[];
+  try {
+    files = database
+      .prepare(`SELECT id, name, pid FROM bf_file LIMIT ${MAX_METADATA_ROWS}`)
+      .all() as JsonObject[];
+  } catch {
+    return false;
+  }
+
+  const seen = new Set<string>();
+  for (const row of files) {
+    const fileId = finiteNumber(row.id);
+    const fileName = safePathSegment(row.name);
+    if (fileId === undefined || fileName === null) continue;
+
+    // Rebuild the recorded folder chain (pid 0 is the library root) without
+    // requiring the chain to resolve: broken references degrade to a
+    // root-level entry so the by-name fallback can still match.
+    const segments: string[] = [];
+    let current = finiteNumber(row.pid) ?? 0;
+    let valid = true;
+    for (let depth = 0; current !== 0; depth += 1) {
+      if (depth >= 64) {
+        valid = false;
+        break;
+      }
+      const folder = folders.get(current);
+      if (!folder) {
+        valid = false;
+        break;
+      }
+      segments.unshift(folder.name);
+      current = folder.pid;
+    }
+    const relative = valid && segments.length > 0 ? [...segments, fileName].join('/') : fileName;
+
+    const data = userdata.get(fileId);
+    const tags: string[] = [];
+    const tagIds = tagIdsByFile.get(fileId);
+    if (tagIds) {
+      for (const tagId of tagIds) {
+        const name = tagNameById.get(tagId);
+        if (name === undefined || tags.includes(name)) continue;
+        tags.push(name);
+      }
+    }
+    const metadata: BillfishAssetMetadata = {
+      description: data && data.note !== '' ? data.note : null,
+      rating: data ? ratingValue(data.score) : 0,
+      sourcePageUrl: data ? httpUrlValue(data.origin) : null,
+      tags,
+      thumbnailPath: null,
+    };
+    if (!metadata.description && metadata.rating === 0 && !metadata.sourcePageUrl && tags.length === 0) {
+      continue;
+    }
+
+    const key = relativeIdentity(relative);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    byPath.set(key, metadata);
+    const name = fileName.toLocaleLowerCase();
+    const sameName = byName.get(name) ?? [];
+    sameName.push(metadata);
+    byName.set(name, sameName);
+  }
+  return true;
+}
+
 function readDatabaseMetadata(root: string, databasePath: string): MetadataIndex {
   const byPath = new Map<string, BillfishAssetMetadata>();
   const byName = new Map<string, BillfishAssetMetadata[]>();
@@ -272,6 +447,14 @@ function readDatabaseMetadata(root: string, databasePath: string): MetadataIndex
     const tables = database
       .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'")
       .all() as Array<{ name?: unknown }>;
+    const tableNames = new Set(
+      tables
+        .map((table) => textValue(table.name, 255).toLocaleLowerCase())
+        .filter((name) => name !== ''),
+    );
+    if (readBillfish3Metadata(database, tableNames, byPath, byName)) {
+      return { byPath, byName, available: true };
+    }
     for (const table of tables.slice(0, 256)) {
       const tableName = textValue(table.name, 255);
       if (tableName === '') continue;

--- a/tests/worker/billfish-import.test.ts
+++ b/tests/worker/billfish-import.test.ts
@@ -49,6 +49,115 @@ function createDatabase(databasePath: string): void {
   database.close();
 }
 
+function createBillfish3Database(databasePath: string): void {
+  const Database = BetterSqlite3 as unknown as {
+    new (filename: string): {
+      exec(sql: string): void;
+      prepare(sql: string): { run(...parameters: unknown[]): void };
+      close(): void;
+    };
+  };
+  const database = new Database(databasePath);
+  database.exec(`
+    CREATE TABLE bf_folder (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      born INTEGER,
+      pid INTEGER NOT NULL,
+      name TEXT,
+      desc TEXT,
+      cover_tid INTEGER,
+      hide INTEGER,
+      seq REAL,
+      color INTEGER,
+      is_recycle INTEGER
+    );
+    CREATE TABLE bf_file (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT,
+      pid INTEGER NOT NULL,
+      is_hide INTEGER,
+      is_link INTEGER,
+      file_size INTEGER,
+      ctime INTEGER,
+      mtime INTEGER,
+      md5 TEXT,
+      tid INTEGER,
+      born INTEGER,
+      ttid INTEGER
+    );
+    CREATE TABLE bf_material_userdata (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      file_id INTEGER NOT NULL,
+      comments_summary TEXT,
+      comments_count INTEGER,
+      comments_detail TEXT,
+      note TEXT,
+      origin TEXT,
+      score INTEGER,
+      rotation INTEGER,
+      hflip INTEGER,
+      vflip INTEGER,
+      cover_tid TEXT,
+      unique(file_id) on conflict replace
+    );
+    CREATE TABLE bf_tag_v2 (
+      id integer primary key autoincrement,
+      name text,
+      pid integer,
+      seq real,
+      icon integer,
+      color integer,
+      born integer
+    );
+    CREATE TABLE bf_tag_join_file (
+      id integer primary key autoincrement,
+      file_id integer,
+      tag_id integer,
+      born integer,
+      unique(file_id, tag_id) on conflict ignore
+    );
+  `);
+  database.prepare('INSERT INTO bf_folder (id, pid, name) VALUES (874, 0, ?)').run('魔法少女的魔女审判');
+  database.prepare('INSERT INTO bf_file (id, name, pid) VALUES (63567, ?, 874)').run('hero.png');
+  database.prepare('INSERT INTO bf_file (id, name, pid) VALUES (63568, ?, 874)').run('untagged.png');
+  database
+    .prepare('INSERT INTO bf_material_userdata (file_id, note, origin, score) VALUES (63567, ?, ?, ?)')
+    .run('A Billfish 3.0 note', 'https://example.com/billfish3', 3);
+  database.prepare('INSERT INTO bf_tag_v2 (id, name, pid) VALUES (65, ?, 0)').run('魔法少女的魔女审判');
+  database.prepare('INSERT INTO bf_tag_v2 (id, name, pid) VALUES (66, ?, 0)').run('reference');
+  database
+    .prepare('INSERT INTO bf_tag_join_file (file_id, tag_id) VALUES (63567, 65)')
+    .run();
+  database
+    .prepare('INSERT INTO bf_tag_join_file (file_id, tag_id) VALUES (63567, 66)')
+    .run();
+  database.close();
+}
+
+function writeBillfish3Library(root: string, flattened: boolean): string {
+  const libraryPath = path.join(root, 'Billfish 3 Library');
+  mkdirSync(path.join(libraryPath, '.bf'), { recursive: true });
+  if (flattened) {
+    // .BillfishPack exports store asset files at the archive root even though
+    // the database still records the original folder hierarchy.
+    writeFileSync(path.join(libraryPath, 'hero.png'), ONE_PX_RED_PNG);
+    const untaggedPng = Buffer.from(ONE_PX_RED_PNG);
+    untaggedPng[20] = (untaggedPng[20] ?? 0) ^ 1;
+    writeFileSync(path.join(libraryPath, 'untagged.png'), untaggedPng);
+  } else {
+    mkdirSync(path.join(libraryPath, '魔法少女的魔女审判'), { recursive: true });
+    writeFileSync(path.join(libraryPath, '魔法少女的魔女审判', 'hero.png'), ONE_PX_RED_PNG);
+    const untaggedPng = Buffer.from(ONE_PX_RED_PNG);
+    untaggedPng[20] = (untaggedPng[20] ?? 0) ^ 1;
+    writeFileSync(
+      path.join(libraryPath, '魔法少女的魔女审判', 'untagged.png'),
+      untaggedPng,
+    );
+  }
+  createBillfish3Database(path.join(libraryPath, '.bf', 'billfish.db'));
+  return libraryPath;
+}
+
 function writeBillfishLibrary(root: string): string {
   const libraryPath = path.join(root, 'Reference Library');
   mkdirSync(path.join(libraryPath, '.bf'), { recursive: true });
@@ -136,6 +245,77 @@ describe('Billfish library import', () => {
         status: 'ready',
         generatorVersion: 'billfish-thumbnail@1',
       });
+    } finally {
+      service.closeAll();
+    }
+  });
+
+  it('reads Billfish 3.x normalized tables when the folder layout matches the database', () => {
+    const sourceRootPath = writeBillfish3Library(temporaryRoot(), false);
+    const snapshot = readBillfishLibrary(sourceRootPath);
+    expect(snapshot.metadataAvailable).toBe(true);
+    const hero = snapshot.items.find((item) => item.relativePath.endsWith('hero.png'));
+    expect(hero?.metadata).toMatchObject({
+      description: 'A Billfish 3.0 note',
+      rating: 3,
+      sourcePageUrl: 'https://example.com/billfish3',
+      tags: ['魔法少女的魔女审判', 'reference'],
+    });
+    const untagged = snapshot.items.find((item) => item.relativePath.endsWith('untagged.png'));
+    expect(untagged?.metadata).toBeNull();
+  });
+
+  it('reads Billfish 3.x metadata for flattened .BillfishPack exports', () => {
+    const sourceRootPath = writeBillfish3Library(temporaryRoot(), true);
+    const snapshot = readBillfishLibrary(sourceRootPath);
+    expect(snapshot.items.map((item) => item.relativePath).sort()).toEqual([
+      'hero.png',
+      'untagged.png',
+    ]);
+    const hero = snapshot.items.find((item) => item.relativePath === 'hero.png');
+    expect(hero?.metadata).toMatchObject({
+      description: 'A Billfish 3.0 note',
+      rating: 3,
+      sourcePageUrl: 'https://example.com/billfish3',
+      tags: ['魔法少女的魔女审判', 'reference'],
+    });
+  });
+
+  it('imports Billfish 3.x notes, ratings, URLs, and tags into a library', async () => {
+    const root = temporaryRoot();
+    const sourceRootPath = writeBillfish3Library(root, false);
+    const service = new LibraryService({
+      observerFactory: () => ({ close() {} }),
+    });
+    try {
+      const library = service.createLibrary({
+        displayName: 'Billfish 3 Target',
+        selectedParentPath: root,
+      });
+      const result = await service.importBillfishLibrary({
+        libraryId: library.libraryId,
+        sourceRootPath,
+      });
+      expect(result.importedCount).toBe(2);
+      expect(result.metadataCount).toBe(1);
+      expect(result.tagCount).toBe(2);
+
+      const assets = service.listAssets({ libraryId: library.libraryId, recursive: true });
+      const hero = assets.find((asset) => asset.relativeFilePath.endsWith('hero.png'));
+      expect(hero).toBeDefined();
+      const heroMetadata = service.getAssetMetadata({
+        libraryId: library.libraryId,
+        assetId: hero!.assetId,
+      });
+      expect(heroMetadata).toMatchObject({
+        description: 'A Billfish 3.0 note',
+        rating: 3,
+        sourcePageUrl: 'https://example.com/billfish3',
+      });
+      expect(heroMetadata.tags.map((tag) => tag.name).sort()).toEqual([
+    'reference',
+    '魔法少女的魔女审判',
+      ].sort());
     } finally {
       service.closeAll();
     }


### PR DESCRIPTION
## Problem

Importing a Billfish 3.x `.BillfishPack` into Serpent silently drops every marker — notes, ratings, source URLs, and tags all disappear.

Billfish 3.x stores metadata across **normalized tables**:

- `bf_file(name, pid)` — file entries (no path column)
- `bf_folder(id, pid, name)` — folder hierarchy
- `bf_material_userdata(file_id, note, origin, score)` — notes / source URL / rating
- `bf_tag_v2(id, name)` + `bf_tag_join_file(file_id, tag_id)` — tags

The generic metadata reader required a path-like column (`path`/`filename`/`filepath`/…) on the table before it would read anything, and it only read scalar columns from a single table. Since no Billfish 3.x table has a path column, every table was skipped and all markers were silently discarded.

## Fix

Added `readBillfish3Metadata()` to `src/worker/billfish-library.ts`, used first when a Billfish database is detected:

- Recognizes `bf_file` as the file table
- Rebuilds each file's recorded folder chain via `bf_folder.pid` to reconstruct the database-relative path
- Reads `note` / `origin` / `score` from `bf_material_userdata` keyed by `file_id`
- Resolves tags through `bf_tag_join_file` → `bf_tag_v2` (with legacy `bf_tag` fallback)

Because exported packs flatten asset files to the archive root while the database still records the original folder layout, entries are indexed **both by database path and by file name** so the existing by-name fallback keeps working.

Also accepts `origin` as a source-URL candidate key in the row mapper.

## Verification

- New regression tests in `tests/worker/billfish-import.test.ts` using the real Billfish 3.x schema (8/8 pass)
- End-to-end verified against real `.BillfishPack` exports from Billfish 3.0: notes, rating, Bilibili source URL, and tags all import correctly
- Full worker suite: `1147 passed`; the 12 failures are pre-existing environment issues (Windows symlink EPERM without admin privileges, hardware-encoder probe, timeout-heavy perf tests), unrelated to this change
- `tsc` and `eslint` clean