### PR TITLE
fix: support JFIF, align folder tree, and recurse folder search

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -84,7 +84,7 @@ import {
   buildLinkedFolderBreadcrumbTrail,
   buildManagedFolderBreadcrumbTrail,
 } from "./folder-breadcrumb-trail";
-import { folderBrowseScope } from "./folder-browse-scope";
+import { folderBrowseScope, folderSearchScope } from "./folder-browse-scope";
 import {
   linkedDirectoryName,
   linkedRevealFolderId,
@@ -5083,23 +5083,18 @@ function AppInner() {
     );
   }
 
-  function currentSearchScope(): SearchScope | undefined {
+  function currentSearchScope(
+    recursivelySearchFolders = false,
+  ): SearchScope | undefined {
     if (activeCollectionId)
       return {
         kind: "collection",
         collectionId: activeCollectionId,
         recursive: collectionRecursive,
       };
-    if (assetScope === "root")
-      return { kind: "folder", folderId: null, recursive: false };
-    if (assetScope !== "all")
-      // REQ-FOLDER-009 / REQ-FILTER-012: folder search follows the same switch.
-      return {
-        kind: "folder",
-        folderId: assetScope,
-        recursive: folderRecursive,
-      };
-    return undefined;
+    return recursivelySearchFolders
+      ? folderSearchScope(assetScope)
+      : folderBrowseScope(assetScope, folderRecursive);
   }
 
   async function reloadCurrentContent() {
@@ -5123,7 +5118,7 @@ function AppInner() {
       : currentQueryDefinition();
     await loadContent(library, assetScope, {
       discovery,
-      searchScope: currentSearchScope(),
+      searchScope: currentSearchScope(discovery.search !== undefined),
     });
   }
 
@@ -5715,11 +5710,14 @@ function AppInner() {
   async function executeSearchDefinition(definition: SearchDefinition) {
     if (!api || !library) return;
     const requestGeneration = ++searchRequestGenerationRef.current;
+    // Resolve once so the first page and every subsequent page use exactly
+    // the same scope even if sidebar state changes while the request is live.
+    const scope = currentSearchScope(definition.search !== undefined);
     const result = await api.searchAssets({
       libraryId: library.libraryId,
       query: definition.search ?? null,
       filters: definition.filters,
-      scope: currentSearchScope(),
+      scope,
       sort: definition.sort,
       // Serpent-87pd: first window only; scrollbar jumps fetch other offsets.
       limit: BROWSE_PAGE_SIZE,
@@ -5742,7 +5740,7 @@ function AppInner() {
       libraryId: library.libraryId,
       query: definition.search ?? null,
       filters: definition.filters,
-      scope: currentSearchScope(),
+      scope,
       sort: definition.sort,
       showIgnored: showIgnoredItems,
       target: "assets",

--- a/src/renderer/NavigationSidebar.tsx
+++ b/src/renderer/NavigationSidebar.tsx
@@ -126,7 +126,7 @@ function NavRow({
     title && title !== label ? `${label} — ${title}` : label;
 
   return (
-    <div className="nav-tree-row">
+    <div className="nav-tree-row" style={{ paddingLeft: depth * 14 }}>
       {disclosure ?? <span className="nav-disclosure-spacer" aria-hidden="true" />}
       <button
         className={`nav-row${active ? " is-active" : ""}${dropActive ? " is-drop-target" : ""}`}
@@ -142,7 +142,7 @@ function NavRow({
         onDrop={onDrop}
         onDragEnter={onDragEnter}
         onDragLeave={onDragLeave}
-        style={{ paddingLeft: 7 + depth * 14 }}
+        style={{ paddingLeft: 7 }}
         title={hoverTitle}
         type="button"
       >
@@ -222,9 +222,9 @@ function InlineFolderEditRow({
   }, [commitOnce]);
 
   return (
-    <div className="nav-tree-row">
+    <div className="nav-tree-row" style={{ paddingLeft: depth * 14 }}>
       <span className="nav-disclosure-spacer" aria-hidden="true" />
-      <div className="nav-inline-edit" style={{ paddingLeft: 7 + depth * 14 }}>
+      <div className="nav-inline-edit" style={{ paddingLeft: 7 }}>
       <Icon name="folder" size={15} />
       <input
         aria-invalid={state.error ? true : undefined}
@@ -338,9 +338,9 @@ function InlineCollectionEditRow({
   }, [commitOnce]);
 
   return (
-    <div className="nav-tree-row">
+    <div className="nav-tree-row" style={{ paddingLeft: depth * 14 }}>
       <span className="nav-disclosure-spacer" aria-hidden="true" />
-      <div className="nav-inline-edit" style={{ paddingLeft: 7 + depth * 14 }}>
+      <div className="nav-inline-edit" style={{ paddingLeft: 7 }}>
         <Icon name="collection" size={15} />
         <input
           aria-label={ariaLabel ?? t("nav.newCollection")}

--- a/src/renderer/folder-browse-scope.ts
+++ b/src/renderer/folder-browse-scope.ts
@@ -17,3 +17,18 @@ export function folderBrowseScope(
   }
   return { kind: "folder", folderId: scope, recursive };
 }
+
+/**
+ * Text search always includes descendants of the selected folder. Keeping
+ * this separate from folderBrowseScope means filters and sorting without a
+ * search term continue to honour the ordinary browse switch.
+ */
+export function folderSearchScope(
+  scope: AssetScopeId,
+): SearchScope | undefined {
+  if (scope === "all") return undefined;
+  if (scope === "root") {
+    return { kind: "folder", folderId: null, recursive: true };
+  }
+  return { kind: "folder", folderId: scope, recursive: true };
+}

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1828,7 +1828,7 @@ body.platform-darwin .app-shell.left-collapsed .toolbar-workspace-cluster {
 
 /* CU-D9: deep/long folder, collection, and smart-collection names ellipsize
    instead of wrapping and inflating row height. Depth indent stays on the
-   button padding; disclosure stays outside .nav-row. */
+   tree row so the disclosure and content advance together. */
 .nav-row-label {
   min-width: 0;
   overflow: hidden;

--- a/src/shared/image-color-space.ts
+++ b/src/shared/image-color-space.ts
@@ -1,3 +1,5 @@
+import { JPEG_IMAGE_EXTENSIONS } from './media-formats';
+
 /** Color-space choices exposed by the locked OCIO configuration. */
 export interface ImageColorSpaceOption {
   id: string;
@@ -18,7 +20,7 @@ export const COMMON_IMAGE_COLOR_SPACE_OPTIONS: readonly ImageColorSpaceOption[] 
 
 /** Formats that can be re-rendered through the bundled OIIO color pipeline. */
 export const COLOR_MANAGED_IMAGE_EXTENSIONS = new Set([
-  '.bmp', '.cr2', '.cr3', '.dng', '.exr', '.ico', '.jpg', '.jpeg', '.nef', '.png',
+  '.bmp', '.cr2', '.cr3', '.dng', '.exr', '.ico', ...JPEG_IMAGE_EXTENSIONS, '.nef', '.png',
   '.orf', '.psd', '.raf', '.raw', '.rw2', '.tga', '.tif', '.tiff', '.webp',
   '.arw',
 ]);

--- a/src/shared/image-sequence.ts
+++ b/src/shared/image-sequence.ts
@@ -1,3 +1,5 @@
+import { JPEG_IMAGE_EXTENSIONS } from "./media-formats";
+
 const IMAGE_SEQUENCE_EXTENSIONS = new Set([
   ".avif",
   ".bmp",
@@ -5,8 +7,7 @@ const IMAGE_SEQUENCE_EXTENSIONS = new Set([
   ".gif",
   ".heic",
   ".heif",
-  ".jpeg",
-  ".jpg",
+  ...JPEG_IMAGE_EXTENSIONS,
   ".png",
   ".psd",
   ".tga",

--- a/src/shared/media-formats.ts
+++ b/src/shared/media-formats.ts
@@ -6,8 +6,11 @@
  * the original file directly; the Worker selects a derivative where needed.
  */
 
+/** Filename extensions that contain the JPEG bitstream. */
+export const JPEG_IMAGE_EXTENSIONS = ['.jpg', '.jpeg', '.jfif'] as const;
+
 export const SHARP_IMAGE_EXTENSIONS = [
-  '.png', '.jpg', '.jpeg', '.gif', '.tif', '.tiff', '.webp', '.svg',
+  '.png', ...JPEG_IMAGE_EXTENSIONS, '.gif', '.tif', '.tiff', '.webp', '.svg',
 ] as const;
 
 /** Formats decoded by the bundled OIIO runtime rather than by Chromium/sharp. */
@@ -116,7 +119,8 @@ export function directImageMimeForExtension(
   switch (normalizedExtension(extensionOrFilename)) {
     case '.png': return 'image/png';
     case '.jpg':
-    case '.jpeg': return 'image/jpeg';
+    case '.jpeg':
+    case '.jfif': return 'image/jpeg';
     case '.gif': return 'image/gif';
     case '.webp': return 'image/webp';
     // SVG stays vector in the viewer; the grid still uses its generated
@@ -130,7 +134,8 @@ export function imageMimeForExtension(extensionOrFilename: string): string | nul
   switch (normalizedExtension(extensionOrFilename)) {
     case '.png': return 'image/png';
     case '.jpg':
-    case '.jpeg': return 'image/jpeg';
+    case '.jpeg':
+    case '.jfif': return 'image/jpeg';
     case '.gif': return 'image/gif';
     case '.tif':
     case '.tiff': return 'image/tiff';

--- a/src/worker/eagle-library.ts
+++ b/src/worker/eagle-library.ts
@@ -8,6 +8,7 @@ import {
 } from 'node:fs';
 import path from 'node:path';
 
+import { JPEG_IMAGE_EXTENSIONS } from '../shared/media-formats';
 import { normalizeAbsolutePath } from './library-rules';
 
 const MAX_METADATA_BYTES = 4 * 1024 * 1024;
@@ -214,7 +215,9 @@ function sourceCandidateScore(
   return 0;
 }
 
-const EAGLE_THUMBNAIL_EXTENSIONS = ['.png', '.jpg', '.jpeg', '.webp', '.gif'];
+const EAGLE_THUMBNAIL_EXTENSIONS = [
+  '.png', ...JPEG_IMAGE_EXTENSIONS, '.webp', '.gif',
+];
 
 function inspectRegularFile(filePath: string): BigIntStats | undefined {
   try {

--- a/src/worker/library-service.ts
+++ b/src/worker/library-service.ts
@@ -25336,7 +25336,11 @@ export class LibraryService {
 
     if (input.scope?.kind === 'folder') {
       if (input.scope.folderId === null) {
-        whereParts.push(`a.location_kind = 'managed' AND a.managed_folder_id IS NULL`);
+        whereParts.push(
+          input.scope.recursive
+            ? `a.location_kind = 'managed'`
+            : `a.location_kind = 'managed' AND a.managed_folder_id IS NULL`,
+        );
       } else {
         const folderId = input.scope.folderId;
         const managed = connection

--- a/src/worker/library-service.ts
+++ b/src/worker/library-service.ts
@@ -552,6 +552,7 @@ import {
 } from '../shared/audio-media';
 import {
   IMAGE_EXTENSIONS,
+  JPEG_IMAGE_EXTENSIONS,
   RAW_IMAGE_EXTENSIONS,
   VIDEO_EXTENSIONS,
   MODEL_EXTENSIONS,
@@ -19052,7 +19053,7 @@ export class LibraryService {
       const extension = path.extname(assetPath).toLowerCase();
       if (
         !imageProcessed &&
-        (extension === '.jpg' || extension === '.jpeg') &&
+        JPEG_IMAGE_EXTENSIONS.includes(extension as (typeof JPEG_IMAGE_EXTENSIONS)[number]) &&
         !execution.signal?.aborted
       ) {
         // Sharp correctly rejects severe JPEG truncation, while FFmpeg can

--- a/src/worker/remote-media-validation.ts
+++ b/src/worker/remote-media-validation.ts
@@ -1,5 +1,7 @@
 import path from 'node:path';
 
+import { JPEG_IMAGE_EXTENSIONS } from '../shared/media-formats';
+
 export type RemoteMediaValidationFailure =
   | 'MIME_TYPE_MISSING'
   | 'MIME_TYPE_UNSUPPORTED'
@@ -38,7 +40,7 @@ const MEDIA_BY_CONTENT_TYPE: Readonly<Record<string, RemoteMediaDefinition>> = {
     matchesMagic: (bytes) => startsWith(bytes, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
   },
   'image/jpeg': {
-    extensions: ['.jpg', '.jpeg'], minimumMagicBytes: 3, preferredExtension: '.jpg',
+    extensions: JPEG_IMAGE_EXTENSIONS, minimumMagicBytes: 3, preferredExtension: '.jpg',
     matchesMagic: (bytes) => startsWith(bytes, [0xff, 0xd8, 0xff]),
   },
   'image/gif': {

--- a/tests/e2e/folder-recursive-scope.test.ts
+++ b/tests/e2e/folder-recursive-scope.test.ts
@@ -180,19 +180,26 @@ test("folder browse stays direct until include-subfolders is checked", async () 
     await expect(parentCard).toHaveCount(0, { timeout: 15_000 });
     await expect(childCard).toHaveCount(0);
 
-    // Explicit switch: include descendants for browse + search.
+    // Text search is recursive even while ordinary browsing remains direct.
+    // There is no explicit search button — submitting the form runs the query.
+    await window.getByLabel("搜索资源库").fill("child-note");
+    await window.getByLabel("搜索资源库").press("Enter");
+    await expect(includeSubfolders).toHaveAttribute("aria-pressed", "false");
+    await expect(childCard).toBeVisible({ timeout: 15_000 });
+    await expect(parentCard).toHaveCount(0);
+
+    // Clearing the term restores the parent's ordinary non-recursive browse.
+    await window.getByLabel("搜索资源库").fill("");
+    await window.getByLabel("搜索资源库").press("Enter");
+    await expect(childCard).toHaveCount(0, { timeout: 15_000 });
+    await expect(parentCard).toHaveCount(0);
+
+    // The explicit switch continues to control descendant inclusion when no
+    // text search is active.
     await includeSubfolders.click();
     await expect(includeSubfolders).toHaveAttribute("aria-pressed", "true");
     await expect(parentCard).toBeVisible({ timeout: 15_000 });
     await expect(childCard).toBeVisible({ timeout: 15_000 });
-
-    // REQ-FILTER-012: searching while scoped to 父文件夹 with include on
-    // recurses into descendant folders. There is no explicit search button —
-    // submitting the search form (Enter) runs the query.
-    await window.getByLabel("搜索资源库").fill("child-note");
-    await window.getByLabel("搜索资源库").press("Enter");
-    await expect(childCard).toBeVisible({ timeout: 15_000 });
-    await expect(parentCard).toHaveCount(0);
   } finally {
     await application.close();
     rmSync(temporaryRoot, { recursive: true, force: true });

--- a/tests/unit/folder-browse-scope.test.ts
+++ b/tests/unit/folder-browse-scope.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { folderBrowseScope } from '../../src/renderer/folder-browse-scope';
+import {
+  folderBrowseScope,
+  folderSearchScope,
+} from '../../src/renderer/folder-browse-scope';
 
 describe('folderBrowseScope (REQ-FOLDER-009)', () => {
   it('leaves all-assets without a folder scope', () => {
@@ -23,6 +26,28 @@ describe('folderBrowseScope (REQ-FOLDER-009)', () => {
       recursive: false,
     });
     expect(folderBrowseScope('folder-a', true)).toEqual({
+      kind: 'folder',
+      folderId: 'folder-a',
+      recursive: true,
+    });
+  });
+});
+
+describe('folderSearchScope', () => {
+  it('leaves all-assets unscoped', () => {
+    expect(folderSearchScope('all')).toBeUndefined();
+  });
+
+  it('searches every managed folder from the library root', () => {
+    expect(folderSearchScope('root')).toEqual({
+      kind: 'folder',
+      folderId: null,
+      recursive: true,
+    });
+  });
+
+  it('always searches descendants of a selected folder', () => {
+    expect(folderSearchScope('folder-a')).toEqual({
       kind: 'folder',
       folderId: 'folder-a',
       recursive: true,

--- a/tests/unit/image-color-space.test.ts
+++ b/tests/unit/image-color-space.test.ts
@@ -36,6 +36,7 @@ describe('image color-space metadata', () => {
 
   it('allows OIIO overrides for ICC-capable raster extensions', () => {
     expect(canOverrideImageColorSpace('preview.png')).toBe(true);
+    expect(canOverrideImageColorSpace('preview.JFIF')).toBe(true);
     expect(canOverrideImageColorSpace('preview.psd')).toBe(true);
     expect(canOverrideImageColorSpace('preview.svg')).toBe(false);
   });

--- a/tests/unit/image-sequence.test.ts
+++ b/tests/unit/image-sequence.test.ts
@@ -34,6 +34,13 @@ describe("parseImageSequenceFileName", () => {
       numericWidth: 0,
       prefix: "photo ",
     });
+    expect(parseImageSequenceFileName("reference_0042.JFIF")).toMatchObject({
+      extension: ".jfif",
+      frameNumber: 42,
+      numberStyle: "trailing",
+      numericWidth: 4,
+      prefix: "reference_",
+    });
     expect(parseImageSequenceFileName("shot_(001).png")).toMatchObject({
       frameNumber: 1,
       numberStyle: "parens",

--- a/tests/unit/media-formats.test.ts
+++ b/tests/unit/media-formats.test.ts
@@ -16,6 +16,10 @@ import {
 describe('media format registry', () => {
   it('routes web-native and derived images through the intended decoder', () => {
     expect(imageDecoderForExtension('poster.PNG')).toBe('sharp');
+    expect(imageDecoderForExtension('poster.JFIF')).toBe('sharp');
+    expect(isSupportedImageExtension('poster.jfif')).toBe(true);
+    expect(directImageMimeForExtension('.jfif')).toBe('image/jpeg');
+    expect(imageMimeForExtension('poster.JFIF')).toBe('image/jpeg');
     expect(imageDecoderForExtension('art.svg')).toBe('sharp');
     for (const extension of ['.bmp', '.ico', '.psd', '.exr', '.tga']) {
       expect(imageDecoderForExtension(extension)).toBe('oiio');

--- a/tests/unit/navigation-sidebar.test.ts
+++ b/tests/unit/navigation-sidebar.test.ts
@@ -217,8 +217,14 @@ describe("NavigationSidebar virtual library root", () => {
     );
     expect(parentFolderRow?.title).toBe(parentFolderName);
     expect(childFolderRow?.title).toBe(childFolderName);
-    expect(parentFolderRow?.style.paddingLeft).toBe("21px");
-    expect(childFolderRow?.style.paddingLeft).toBe("35px");
+    expect(parentFolderRow?.style.paddingLeft).toBe("7px");
+    expect(childFolderRow?.style.paddingLeft).toBe("7px");
+    expect(parentFolderRow?.closest<HTMLElement>(".nav-tree-row")?.style.paddingLeft).toBe(
+      "14px",
+    );
+    expect(childFolderRow?.closest<HTMLElement>(".nav-tree-row")?.style.paddingLeft).toBe(
+      "28px",
+    );
     expect(
       parentFolderRow?.closest(".nav-tree-row")?.querySelector(".nav-disclosure"),
     ).not.toBeNull();
@@ -243,7 +249,13 @@ describe("NavigationSidebar virtual library root", () => {
     expect(parentCollectionRow?.title).toBe(parentCollectionName);
     expect(childCollectionRow?.title).toBe(childCollectionName);
     expect(parentCollectionRow?.style.paddingLeft).toBe("7px");
-    expect(childCollectionRow?.style.paddingLeft).toBe("21px");
+    expect(childCollectionRow?.style.paddingLeft).toBe("7px");
+    expect(
+      parentCollectionRow?.closest<HTMLElement>(".nav-tree-row")?.style.paddingLeft,
+    ).toBe("0px");
+    expect(
+      childCollectionRow?.closest<HTMLElement>(".nav-tree-row")?.style.paddingLeft,
+    ).toBe("14px");
     expect(parentCollectionRow?.classList.contains("is-active")).toBe(false);
     expect(childCollectionRow?.classList.contains("is-active")).toBe(true);
     expect(parentCollectionRow?.querySelectorAll(".nav-count")).toHaveLength(1);

--- a/tests/worker/extension-save.test.ts
+++ b/tests/worker/extension-save.test.ts
@@ -383,6 +383,7 @@ describe('saveAssetFromUrl', () => {
   it.each([
     ['image/png', 'asset.png'],
     ['image/jpeg', 'asset.jpeg'],
+    ['image/jpeg', 'asset.jfif'],
     ['image/gif', 'asset.gif'],
     ['image/tiff', 'asset.tif'],
     ['image/webp', 'asset.webp'],

--- a/tests/worker/search.test.ts
+++ b/tests/worker/search.test.ts
@@ -772,6 +772,55 @@ describe('FTS5 trigram query builder', () => {
 // ── Search Filters ──────────────────────────────────────────────────
 
 describe('search filters', () => {
+  it('recurses from the library root across managed folders without including linked assets', () => {
+    const { service, libraryId, libraryPath, assetId: nestedManagedAssetId } =
+      createLibraryWithAssetAndTags();
+    const rootAssetId = randomUUID();
+    const rootRevisionId = randomUUID();
+    const rootFileName = 'root-direct.png';
+    const now = new Date().toISOString();
+    writeFileSync(path.join(libraryPath, 'Assets', rootFileName), 'root asset');
+
+    const db = new TestDatabase(path.join(libraryPath, '.serpent', 'library.db'));
+    try {
+      db.prepare(
+        `INSERT INTO assets (asset_id, location_kind, managed_folder_id, linked_folder_id,
+          relative_file_path, current_revision_id, availability, path_identity, created_at, updated_at)
+         VALUES (?, 'managed', NULL, NULL, ?, NULL, 'available', ?, ?, ?)`,
+      ).run(rootAssetId, rootFileName, rootFileName, now, now);
+      db.prepare(
+        `INSERT INTO revisions (revision_id, asset_id, parent_revision_id, byte_size,
+          modified_at, original_filename, origin, accepted_at)
+         VALUES (?, ?, NULL, 10, ?, ?, 'import', ?)`,
+      ).run(rootRevisionId, rootAssetId, now, rootFileName, now);
+      db.prepare('UPDATE assets SET current_revision_id = ? WHERE asset_id = ?')
+        .run(rootRevisionId, rootAssetId);
+    } finally {
+      db.close();
+    }
+
+    const linkedRoot = path.join(path.dirname(libraryPath), 'linked-root-scope');
+    mkdirSync(linkedRoot);
+    writeFileSync(path.join(linkedRoot, 'linked.png'), 'linked asset');
+    service.importFolderAsLinked({ libraryId, sourceRootPath: linkedRoot });
+
+    const direct = service.searchAssets({
+      libraryId,
+      scope: { kind: 'folder', folderId: null, recursive: false },
+    });
+    const recursive = service.searchAssets({
+      libraryId,
+      scope: { kind: 'folder', folderId: null, recursive: true },
+    });
+
+    expect(direct.items.map((asset) => asset.assetId)).toEqual([rootAssetId]);
+    expect(recursive.items.map((asset) => asset.assetId).sort()).toEqual(
+      [rootAssetId, nestedManagedAssetId].sort(),
+    );
+    expect(recursive.items.every((asset) => asset.locationKind === 'managed')).toBe(true);
+    service.closeAll();
+  });
+
   it('scopes ordinary browsing to managed folders with optional descendants', () => {
     const { service, libraryId, libraryPath, assetId } = createLibraryWithAssetAndTags();
     const parent = service.listManagedFolders(libraryId)[0]!;

--- a/tests/worker/thumbnails.test.ts
+++ b/tests/worker/thumbnails.test.ts
@@ -76,6 +76,20 @@ async function createPngBytes(width: number, height: number): Promise<Buffer> {
   }).png().toBuffer();
 }
 
+async function createJpegBytes(width: number, height: number): Promise<Buffer> {
+  const sharp = require('sharp') as (input: unknown) => {
+    jpeg(): { toBuffer(): Promise<Buffer> };
+  };
+  return sharp({
+    create: {
+      width,
+      height,
+      channels: 3,
+      background: { r: 220, g: 120, b: 40 },
+    },
+  }).jpeg().toBuffer();
+}
+
 function importNoConflict(service: LibraryService, libraryId: string, sourcePath: string): void {
   sharedImportNoConflict(service, libraryId, sourcePath);
 }
@@ -165,7 +179,7 @@ describe('schema v9 migration', () => {
 describe('detectMediaType', () => {
   it('detects product image types, including OIIO and RAW derivatives', () => {
     for (const filename of [
-      'photo.png', 'photo.jpeg', 'photo.gif', 'photo.webp', 'photo.bmp',
+      'photo.png', 'photo.jpeg', 'photo.JFIF', 'photo.gif', 'photo.webp', 'photo.bmp',
       'photo.tiff', 'photo.tga', 'photo.exr', 'photo.ico', 'layer.psd',
       'camera.dng', 'camera.cr2', 'camera.cr3', 'camera.nef', 'camera.arw',
       'camera.raf', 'camera.orf', 'camera.rw2',
@@ -189,6 +203,38 @@ describe('detectMediaType', () => {
 });
 
 describe('generateThumbnail (sharp)', () => {
+  it('imports, thumbnails, and serves a JPEG bitstream with a .jfif filename', async () => {
+    const root = temporaryRoot();
+    const service = new LibraryService();
+    const created = service.createLibrary({ displayName: 'Jfif', selectedParentPath: root });
+    const sourcePath = path.join(root, 'reference.jfif');
+    writeFileSync(sourcePath, await createJpegBytes(24, 16));
+    importNoConflict(service, created.libraryId, sourcePath);
+    const asset = service.listAssets({ libraryId: created.libraryId, recursive: true })[0]!;
+
+    await expect(service.generateThumbnail({
+      libraryId: created.libraryId,
+      assetId: asset.assetId,
+    })).resolves.toMatchObject({ artifactId: expect.any(String) });
+    expect(service.listAssets({
+      libraryId: created.libraryId,
+      recursive: true,
+    })[0]).toMatchObject({ width: 24, height: 16 });
+    expect(service.getPreviewArtifact(created.libraryId, asset.assetId)).toMatchObject({
+      mediaType: 'image',
+      status: 'ready',
+      playbackMode: 'source',
+      sourceMimeType: 'image/jpeg',
+    });
+    expect(service.getCurrentMediaSource(
+      created.libraryId,
+      asset.assetId,
+      asset.currentRevisionId,
+    )).toMatchObject({ mimeType: 'image/jpeg' });
+
+    service.closeAll();
+  });
+
   it('uses a bounded plugin artifact from the media queue before native decoding', async () => {
     const root = temporaryRoot();
     const service = new LibraryService();


### PR DESCRIPTION
## 修复内容

- 将 `.jfif` 注册为 JPEG 别名，统一走 Sharp 解码与 `image/jpeg` MIME；覆盖导入、缩略图、预览、格式筛选、远程下载校验、JPEG 容错恢复、色彩管理和图片序列识别。
- 将文件夹/合集树的深度缩进移动到整行容器，使展开箭头、占位符与文件夹内容按每级 14px 一起缩进；行内新建和重命名保持一致。
- 将文本搜索与普通浏览范围解耦：输入搜索词时自动覆盖当前文件夹全部后代，清空搜索后恢复“包含子文件夹”开关控制的普通浏览范围。
- 补齐 `folderId: null, recursive: true` 的资源库根目录语义：包含全部托管目录，但不会混入独立关联文件夹。
- 首页、分页和刷新复用同一个已计算搜索范围；合集递归行为与现有搜索协议保持不变。

## 行为变化

| 场景 | 修改前 | 修改后 |
| --- | --- | --- |
| `.jfif` 文件 | 无法作为受支持图片完整处理 | 按 JPEG 导入、缩略、预览与筛选 |
| 子级文件夹展开图标 | 箭头停留在树最左侧 | 箭头与整行一起按层级缩进 |
| 文件夹内文本搜索 | 只搜索当前文件夹 | 自动搜索当前文件夹及全部后代 |
| 清空搜索词 | — | 恢复普通非递归浏览范围 |
| 资源库根目录递归搜索 | 只包含根目录直属文件 | 包含全部托管目录且排除关联文件夹 |

## 测试结果

通过：

- `npm run typecheck`
- `npm run lint`
- 相关 Renderer 单元测试：10 tests passed
- `tests/worker/search.test.ts`：88 tests passed
- `tests/worker/extension-save.test.ts` + `tests/worker/thumbnails.test.ts`：117 tests passed
- Node ABI 全量 Vitest：4030 tests passed、25 skipped

环境限制：

- `npm test` 的 Electron ABI 预检需要本机 Visual Studio C++ workload 来重建 `better-sqlite3`，当前环境未安装，因此在测试执行前中止。
- Node ABI 全量 Vitest 另有 13 个既有 Windows 环境失败：12 个符号链接权限/清理错误，以及 1 个 8.3 短路径与长路径断言差异。
- `folder-recursive-scope` Playwright 已构建并启动，但同样因 Electron `better-sqlite3` ABI 不可用，资源库 Worker 未能启动，3 个用例在等待文件夹控件时超时。

## 视觉对比

修改前展开箭头固定在树左边缘；修改后展开箭头、占位符和文件夹内容共同按每级 14px 缩进，同时文件夹图标、文字和计数的相对位置保持不变。当前 Windows 测试机因上述 Electron 原生模块构建限制无法生成可靠的运行时“修改后”截图，相关 DOM 层级与交互由 `navigation-sidebar.test.ts` 覆盖。

未升级版本、未修改发布说明、未引入数据库迁移。