### PR TITLE
fix(ui): indent folder disclosure controls

### DIFF
--- a/src/renderer/NavigationSidebar.tsx
+++ b/src/renderer/NavigationSidebar.tsx
@@ -126,7 +126,7 @@ function NavRow({
     title && title !== label ? `${label} — ${title}` : label;
 
   return (
-    <div className="nav-tree-row">
+    <div className="nav-tree-row" style={{ paddingLeft: depth * 14 }}>
       {disclosure ?? <span className="nav-disclosure-spacer" aria-hidden="true" />}
       <button
         className={`nav-row${active ? " is-active" : ""}${dropActive ? " is-drop-target" : ""}`}
@@ -142,7 +142,7 @@ function NavRow({
         onDrop={onDrop}
         onDragEnter={onDragEnter}
         onDragLeave={onDragLeave}
-        style={{ paddingLeft: 7 + depth * 14 }}
+        style={{ paddingLeft: 7 }}
         title={hoverTitle}
         type="button"
       >
@@ -222,9 +222,9 @@ function InlineFolderEditRow({
   }, [commitOnce]);
 
   return (
-    <div className="nav-tree-row">
+    <div className="nav-tree-row" style={{ paddingLeft: depth * 14 }}>
       <span className="nav-disclosure-spacer" aria-hidden="true" />
-      <div className="nav-inline-edit" style={{ paddingLeft: 7 + depth * 14 }}>
+      <div className="nav-inline-edit" style={{ paddingLeft: 7 }}>
       <Icon name="folder" size={15} />
       <input
         aria-invalid={state.error ? true : undefined}
@@ -338,9 +338,9 @@ function InlineCollectionEditRow({
   }, [commitOnce]);
 
   return (
-    <div className="nav-tree-row">
+    <div className="nav-tree-row" style={{ paddingLeft: depth * 14 }}>
       <span className="nav-disclosure-spacer" aria-hidden="true" />
-      <div className="nav-inline-edit" style={{ paddingLeft: 7 + depth * 14 }}>
+      <div className="nav-inline-edit" style={{ paddingLeft: 7 }}>
         <Icon name="collection" size={15} />
         <input
           aria-label={ariaLabel ?? t("nav.newCollection")}

--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1833,7 +1833,7 @@ body.platform-darwin .app-shell.left-collapsed .toolbar-workspace-cluster {
 
 /* CU-D9: deep/long folder, collection, and smart-collection names ellipsize
    instead of wrapping and inflating row height. Depth indent stays on the
-   button padding; disclosure stays outside .nav-row. */
+   tree row so the disclosure and content advance together. */
 .nav-row-label {
   min-width: 0;
   overflow: hidden;

--- a/tests/unit/navigation-sidebar.test.ts
+++ b/tests/unit/navigation-sidebar.test.ts
@@ -249,8 +249,14 @@ describe("NavigationSidebar virtual library root", () => {
     );
     expect(parentFolderRow?.title).toBe(parentFolderName);
     expect(childFolderRow?.title).toBe(childFolderName);
-    expect(parentFolderRow?.style.paddingLeft).toBe("21px");
-    expect(childFolderRow?.style.paddingLeft).toBe("35px");
+    expect(parentFolderRow?.style.paddingLeft).toBe("7px");
+    expect(childFolderRow?.style.paddingLeft).toBe("7px");
+    expect(parentFolderRow?.closest<HTMLElement>(".nav-tree-row")?.style.paddingLeft).toBe(
+      "14px",
+    );
+    expect(childFolderRow?.closest<HTMLElement>(".nav-tree-row")?.style.paddingLeft).toBe(
+      "28px",
+    );
     expect(
       parentFolderRow?.closest(".nav-tree-row")?.querySelector(".nav-disclosure"),
     ).not.toBeNull();
@@ -275,7 +281,13 @@ describe("NavigationSidebar virtual library root", () => {
     expect(parentCollectionRow?.title).toBe(parentCollectionName);
     expect(childCollectionRow?.title).toBe(childCollectionName);
     expect(parentCollectionRow?.style.paddingLeft).toBe("7px");
-    expect(childCollectionRow?.style.paddingLeft).toBe("21px");
+    expect(childCollectionRow?.style.paddingLeft).toBe("7px");
+    expect(
+      parentCollectionRow?.closest<HTMLElement>(".nav-tree-row")?.style.paddingLeft,
+    ).toBe("0px");
+    expect(
+      childCollectionRow?.closest<HTMLElement>(".nav-tree-row")?.style.paddingLeft,
+    ).toBe("14px");
     expect(parentCollectionRow?.classList.contains("is-active")).toBe(false);
     expect(childCollectionRow?.classList.contains("is-active")).toBe(true);
     expect(parentCollectionRow?.querySelectorAll(".nav-count")).toHaveLength(1);


### PR DESCRIPTION
## 问题

嵌套文件夹的展开箭头始终贴在树的最左侧，没有随父子层级缩进，导致箭头、文件夹图标和文字的视觉层级不一致。

## 变更

- 将每级 14px 的深度缩进从文件夹按钮内部移动到整行容器。
- 展开箭头、无子项占位符和文件夹内容现在共同随层级移动。
- 保持文件夹图标、文字和计数之间的相对位置不变。
- 同步覆盖托管文件夹、关联文件夹、合集树以及行内新建/重命名状态。

## 范围

这是从 #15 拆出的独立 UI 修复，只修改以下 3 个文件，不包含 JFIF 或搜索行为变更：

- `src/renderer/NavigationSidebar.tsx`
- `src/renderer/styles.css`
- `tests/unit/navigation-sidebar.test.ts`

## 测试

- `npm run typecheck`
- `npm run lint`
- `npx vitest run tests/unit/navigation-sidebar.test.ts` — 6 tests passed