### PR TITLE
fix(search): search folder descendants by default

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -98,7 +98,7 @@ import {
   buildLinkedFolderBreadcrumbTrail,
   buildManagedFolderBreadcrumbTrail,
 } from "./folder-breadcrumb-trail";
-import { folderBrowseScope } from "./folder-browse-scope";
+import { folderBrowseScope, folderSearchScope } from "./folder-browse-scope";
 import {
   linkedDirectoryName,
   linkedRevealFolderId,
@@ -5653,23 +5653,18 @@ function AppInner() {
     );
   }
 
-  function currentSearchScope(): SearchScope | undefined {
+  function currentSearchScope(
+    recursivelySearchFolders = false,
+  ): SearchScope | undefined {
     if (activeCollectionId)
       return {
         kind: "collection",
         collectionId: activeCollectionId,
         recursive: collectionRecursive,
       };
-    if (assetScope === "root")
-      return { kind: "folder", folderId: null, recursive: false };
-    if (assetScope !== "all")
-      // REQ-FOLDER-009 / REQ-FILTER-012: folder search follows the same switch.
-      return {
-        kind: "folder",
-        folderId: assetScope,
-        recursive: folderRecursive,
-      };
-    return undefined;
+    return recursivelySearchFolders
+      ? folderSearchScope(assetScope)
+      : folderBrowseScope(assetScope, folderRecursive);
   }
 
   async function reloadCurrentContent(options?: {
@@ -5696,7 +5691,7 @@ function AppInner() {
       : currentQueryDefinition();
     await loadContent(library, assetScope, {
       discovery,
-      searchScope: currentSearchScope(),
+      searchScope: currentSearchScope(discovery.search !== undefined),
       blockingLibraryLoad: options?.blockingNavigation,
     });
   }
@@ -6348,7 +6343,9 @@ function AppInner() {
   async function executeSearchDefinition(definition: SearchDefinition) {
     if (!api || !library) return;
     const requestGeneration = ++searchRequestGenerationRef.current;
-    const searchScope = currentSearchScope();
+    // Resolve once so the first page and every subsequent page use exactly
+    // the same scope even if sidebar state changes while the request is live.
+    const searchScope = currentSearchScope(definition.search !== undefined);
     const result = await api.openBrowseSession({
       libraryId: library.libraryId,
       query: definition.search ?? null,

--- a/src/renderer/folder-browse-scope.ts
+++ b/src/renderer/folder-browse-scope.ts
@@ -17,3 +17,18 @@ export function folderBrowseScope(
   }
   return { kind: "folder", folderId: scope, recursive };
 }
+
+/**
+ * Text search always includes descendants of the selected folder. Keeping
+ * this separate from folderBrowseScope means filters and sorting without a
+ * search term continue to honour the ordinary browse switch.
+ */
+export function folderSearchScope(
+  scope: AssetScopeId,
+): SearchScope | undefined {
+  if (scope === "all") return undefined;
+  if (scope === "root") {
+    return { kind: "folder", folderId: null, recursive: true };
+  }
+  return { kind: "folder", folderId: scope, recursive: true };
+}

--- a/src/worker/library-service.ts
+++ b/src/worker/library-service.ts
@@ -29761,7 +29761,11 @@ export class LibraryService {
 
     if (input.scope?.kind === 'folder') {
       if (input.scope.folderId === null) {
-        whereParts.push(`a.location_kind = 'managed' AND a.managed_folder_id IS NULL`);
+        whereParts.push(
+          input.scope.recursive
+            ? `a.location_kind = 'managed'`
+            : `a.location_kind = 'managed' AND a.managed_folder_id IS NULL`,
+        );
       } else {
         const folderId = input.scope.folderId;
         const managed = connection

--- a/tests/e2e/folder-recursive-scope.test.ts
+++ b/tests/e2e/folder-recursive-scope.test.ts
@@ -180,19 +180,26 @@ test("folder browse stays direct until include-subfolders is checked", async () 
     await expect(parentCard).toHaveCount(0, { timeout: 15_000 });
     await expect(childCard).toHaveCount(0);
 
-    // Explicit switch: include descendants for browse + search.
+    // Text search is recursive even while ordinary browsing remains direct.
+    // There is no explicit search button — submitting the form runs the query.
+    await window.getByLabel("搜索资源库").fill("child-note");
+    await window.getByLabel("搜索资源库").press("Enter");
+    await expect(includeSubfolders).toHaveAttribute("aria-pressed", "false");
+    await expect(childCard).toBeVisible({ timeout: 15_000 });
+    await expect(parentCard).toHaveCount(0);
+
+    // Clearing the term restores the parent's ordinary non-recursive browse.
+    await window.getByLabel("搜索资源库").fill("");
+    await window.getByLabel("搜索资源库").press("Enter");
+    await expect(childCard).toHaveCount(0, { timeout: 15_000 });
+    await expect(parentCard).toHaveCount(0);
+
+    // The explicit switch continues to control descendant inclusion when no
+    // text search is active.
     await includeSubfolders.click();
     await expect(includeSubfolders).toHaveAttribute("aria-pressed", "true");
     await expect(parentCard).toBeVisible({ timeout: 15_000 });
     await expect(childCard).toBeVisible({ timeout: 15_000 });
-
-    // REQ-FILTER-012: searching while scoped to 父文件夹 with include on
-    // recurses into descendant folders. There is no explicit search button —
-    // submitting the search form (Enter) runs the query.
-    await window.getByLabel("搜索资源库").fill("child-note");
-    await window.getByLabel("搜索资源库").press("Enter");
-    await expect(childCard).toBeVisible({ timeout: 15_000 });
-    await expect(parentCard).toHaveCount(0);
   } finally {
     await application.close();
     rmSync(temporaryRoot, { recursive: true, force: true });

--- a/tests/unit/folder-browse-scope.test.ts
+++ b/tests/unit/folder-browse-scope.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { folderBrowseScope } from '../../src/renderer/folder-browse-scope';
+import {
+  folderBrowseScope,
+  folderSearchScope,
+} from '../../src/renderer/folder-browse-scope';
 
 describe('folderBrowseScope (REQ-FOLDER-009)', () => {
   it('leaves all-assets without a folder scope', () => {
@@ -23,6 +26,28 @@ describe('folderBrowseScope (REQ-FOLDER-009)', () => {
       recursive: false,
     });
     expect(folderBrowseScope('folder-a', true)).toEqual({
+      kind: 'folder',
+      folderId: 'folder-a',
+      recursive: true,
+    });
+  });
+});
+
+describe('folderSearchScope', () => {
+  it('leaves all-assets unscoped', () => {
+    expect(folderSearchScope('all')).toBeUndefined();
+  });
+
+  it('searches every managed folder from the library root', () => {
+    expect(folderSearchScope('root')).toEqual({
+      kind: 'folder',
+      folderId: null,
+      recursive: true,
+    });
+  });
+
+  it('always searches descendants of a selected folder', () => {
+    expect(folderSearchScope('folder-a')).toEqual({
       kind: 'folder',
       folderId: 'folder-a',
       recursive: true,

--- a/tests/worker/search.test.ts
+++ b/tests/worker/search.test.ts
@@ -772,6 +772,55 @@ describe('FTS5 trigram query builder', () => {
 // ── Search Filters ──────────────────────────────────────────────────
 
 describe('search filters', () => {
+  it('recurses from the library root across managed folders without including linked assets', () => {
+    const { service, libraryId, libraryPath, assetId: nestedManagedAssetId } =
+      createLibraryWithAssetAndTags();
+    const rootAssetId = randomUUID();
+    const rootRevisionId = randomUUID();
+    const rootFileName = 'root-direct.png';
+    const now = new Date().toISOString();
+    writeFileSync(path.join(libraryPath, 'Assets', rootFileName), 'root asset');
+
+    const db = new TestDatabase(path.join(libraryPath, '.serpent', 'library.db'));
+    try {
+      db.prepare(
+        `INSERT INTO assets (asset_id, location_kind, managed_folder_id, linked_folder_id,
+          relative_file_path, current_revision_id, availability, path_identity, created_at, updated_at)
+         VALUES (?, 'managed', NULL, NULL, ?, NULL, 'available', ?, ?, ?)`,
+      ).run(rootAssetId, rootFileName, rootFileName, now, now);
+      db.prepare(
+        `INSERT INTO revisions (revision_id, asset_id, parent_revision_id, byte_size,
+          modified_at, original_filename, origin, accepted_at)
+         VALUES (?, ?, NULL, 10, ?, ?, 'import', ?)`,
+      ).run(rootRevisionId, rootAssetId, now, rootFileName, now);
+      db.prepare('UPDATE assets SET current_revision_id = ? WHERE asset_id = ?')
+        .run(rootRevisionId, rootAssetId);
+    } finally {
+      db.close();
+    }
+
+    const linkedRoot = path.join(path.dirname(libraryPath), 'linked-root-scope');
+    mkdirSync(linkedRoot);
+    writeFileSync(path.join(linkedRoot, 'linked.png'), 'linked asset');
+    service.importFolderAsLinked({ libraryId, sourceRootPath: linkedRoot });
+
+    const direct = service.searchAssets({
+      libraryId,
+      scope: { kind: 'folder', folderId: null, recursive: false },
+    });
+    const recursive = service.searchAssets({
+      libraryId,
+      scope: { kind: 'folder', folderId: null, recursive: true },
+    });
+
+    expect(direct.items.map((asset) => asset.assetId)).toEqual([rootAssetId]);
+    expect(recursive.items.map((asset) => asset.assetId).sort()).toEqual(
+      [rootAssetId, nestedManagedAssetId].sort(),
+    );
+    expect(recursive.items.every((asset) => asset.locationKind === 'managed')).toBe(true);
+    service.closeAll();
+  });
+
   it('scopes ordinary browsing to managed folders with optional descendants', () => {
     const { service, libraryId, libraryPath, assetId } = createLibraryWithAssetAndTags();
     const parent = service.listManagedFolders(libraryId)[0]!;


### PR DESCRIPTION
## 问题

当前文件夹的文本搜索复用了普通浏览的“包含子文件夹”开关；开关关闭时，父文件夹搜索无法命中子文件夹和孙级文件。

## 变更

- 将文本搜索范围与普通浏览范围解耦：存在搜索词时自动搜索当前文件夹及全部后代。
- 清空搜索词后恢复由“包含子文件夹”开关控制的普通浏览范围。
- 资源库根目录递归搜索覆盖全部托管目录，但不会混入独立关联文件夹。
- 关联文件夹及其虚拟子目录按路径前缀递归。
- 合集仍沿用现有合集递归设置；只有格式筛选或排序而没有搜索词时，仍遵循普通浏览范围。
- 首屏、分页与刷新复用同一个已计算范围，并适配 `dev` 上最新的浏览会话 API。
- 补齐 Worker 对 `folderId: null, recursive: true` 的根目录递归语义。

## 范围

这是从 #15 拆出的独立搜索修复，不包含 JFIF 或文件夹树样式改动。

## 测试

- `npm run typecheck`
- `npm run lint`
- `npx vitest run tests/unit/folder-browse-scope.test.ts tests/worker/search.test.ts` — 94 tests passed

Playwright 用例已同步更新；本机未运行 Electron E2E，原因与 #15 中记录的原生模块 ABI 环境限制相同。